### PR TITLE
Fix typo in docs.md

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -15,6 +15,6 @@ Open the file in your personal IDE like VS Code.
 2. Wait for your order to arrive
 3. Give the items to your pets.
 
-- Feed your fish
+- Feed your Phish
 - Give your cat a toy
-- Walk your dog on a new leash
+- Walk your dog on a brand new leash


### PR DESCRIPTION
Fix typo in `docs.md`.

Closes #13.

Created from ClickUp task [Github MCP testing](https://app.clickup-stg.com/t/8xdfu9jyf).